### PR TITLE
Fix: `sensitive` mapped as `off` for series 4000

### DIFF
--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -69,7 +69,7 @@ SMART_SERIES_MODES = {
 }
 
 
-SMART_SERIES_6000_MODES = SMART_SERIES_4000_MODES = SMART_SERIES_MODES | {2: "off"}
+SMART_SERIES_6000_MODES = SMART_SERIES_MODES | {2: "off"}
 
 
 IO_SERIES_MODES = {
@@ -100,7 +100,7 @@ DEVICE_TYPES = {
     ),
     Models.SmartSeries4000: ModelDescription(
         device_type="Smart Series 4000",
-        modes=SMART_SERIES_4000_MODES,
+        modes=SMART_SERIES_MODES,
     ),
     Models.SmartSeries6000: ModelDescription(
         device_type="Smart Series 6000",


### PR DESCRIPTION
Fixes #22 (reported by myself).

Not sure if this is the intended way to fix this, just trying to be helpful here :-) 