### PR TITLE
feat: add support for IO Series 6 and Tongue Cleaning Mode

### DIFF
--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -41,7 +41,7 @@ class Models(Enum):
     TriumphV2 = auto()
     IOSeries8 = auto()
     IOSeries9 = auto()
-    IOSeries78 = auto()
+    IOSeries67 = auto()
     IOSeries4 = auto()
     SmartSeries4000 = auto()
     SmartSeries6000 = auto()
@@ -87,8 +87,8 @@ IO_SERIES_MODES = {
 DEVICE_TYPES = {
     Models.Pro6000: ModelDescription("Pro 6000", SMART_SERIES_MODES),
     Models.TriumphV2: ModelDescription("Triumph V2", SMART_SERIES_MODES),
-    Models.IOSeries78: ModelDescription(
-        device_type="IO Series 7/8",
+    Models.IOSeries67: ModelDescription(
+        device_type="IO Series 6/7",
         modes=IO_SERIES_MODES,
     ),
     Models.IOSeries8: ModelDescription(
@@ -165,7 +165,7 @@ ORALB_MANUFACTURER = 0x00DC
 
 
 BYTES_TO_MODEL = {
-    b"\x062k": Models.IOSeries78,
+    b"\x062k": Models.IOSeries67,
     b"\x074\x0c": Models.IOSeries4,
     b"\x03V\x04": Models.SmartSeries4000,
     b"\x04'\r": Models.SmartSeries6000,

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -80,6 +80,7 @@ IO_SERIES_MODES = {
     3: "whiten",
     4: "intense",
     5: "super sensitive",
+    6: "tongue cleaning",
     8: "settings",
 }
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -53,6 +53,15 @@ ORALB_DATA_4 = BluetoothServiceInfo(
     service_data={},
     source="local",
 )
+ORALB_IO_SERIES_6 = BluetoothServiceInfo(
+    name="78:DB:2F:C2:48:BE",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x062k\x02r\x00\x00\x01\x01\x00\x04"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
 ORALB_IO_SERIES_7 = BluetoothServiceInfo(
     name="78:DB:2F:C2:48:BE",
     address="78:DB:2F:C2:48:BE",
@@ -111,7 +120,7 @@ ORALB_IO_SERIES_9 = BluetoothServiceInfo(
 ORALB_4000_SERIES = BluetoothServiceInfo(
     address="78:DB:2F:C2:48:BE",
     rssi=-63,
-    name="9000",
+    name="4000",
     manufacturer_data={220: b"\x03V\x04\x030\x00\x00\x01\x01\x00\x04"},
     service_uuids=[],
     service_data={},
@@ -185,6 +194,43 @@ GENIUS_8000_HIGH_PRESSURE = BluetoothServiceInfo(
     rssi=-63,
     name="GENIUS8000",
     manufacturer_data={220: b'\x03"\x0c\x03\xc0\x010\x07\x04<\x04'},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+
+ORALB_IO_SERIES_6_DAILY_CLEAN = BluetoothServiceInfo(
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    name="Oral-B Toothbrush",
+    manufacturer_data={220: b"\x062k\x02r\x00\x00\x00\x01\x00\x04"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+ORALB_IO_SERIES_6_SENSITIVE = BluetoothServiceInfo(
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    name="Oral-B Toothbrush",
+    manufacturer_data={220: b"\x062k\x02r\x00\x00\x01\x01\x00\x04"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+ORALB_IO_SERIES_6_GUM_CARE = BluetoothServiceInfo(
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    name="Oral-B Toothbrush",
+    manufacturer_data={220: b"\x062k\x02r\x00\x00\x02\x01\x00\x04"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+ORALB_IO_SERIES_6_WHITEN = BluetoothServiceInfo(
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    name="Oral-B Toothbrush",
+    manufacturer_data={220: b"\x062k\x02r\x00\x00\x03\x01\x00\x04"},
     service_uuids=[],
     service_data={},
     source="local",
@@ -655,16 +701,591 @@ def test_dataset_4():
     )
 
 
+def test_io_series_6():
+    parser = OralBBluetoothDeviceData()
+    service_info = ORALB_IO_SERIES_6
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title="IO Series 6/7 48BE",
+        devices={
+            None: SensorDeviceInfo(
+                name="IO Series 6/7 48BE",
+                model="IO Series 6/7",
+                manufacturer="Oral-B",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="mode", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="mode", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="time", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="time", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorValue(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                name="Number " "of " "sectors",
+                native_value=4,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                name="Sector " "Timer",
+                native_value=0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-63,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector", device_id=None),
+                name="Sector",
+                native_value="sector " "1",
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                name="Toothbrush " "State",
+                native_value="idle",
+            ),
+            DeviceKey(key="mode", device_id=None): SensorValue(
+                device_key=DeviceKey(key="mode", device_id=None),
+                name="Mode",
+                native_value="sensitive",
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorValue(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                name="Pressure",
+                native_value="normal",
+            ),
+            DeviceKey(key="time", device_id=None): SensorValue(
+                device_key=DeviceKey(key="time", device_id=None),
+                name="Time",
+                native_value=0,
+            ),
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="brushing", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="brushing", device_id=None), device_class=None
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="brushing", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="brushing", device_id=None),
+                name="Brushing",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
+def test_io_series_6_daily_clean_mode():
+    parser = OralBBluetoothDeviceData()
+    service_info = ORALB_IO_SERIES_6_DAILY_CLEAN
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title="IO Series 6/7 48BE",
+        devices={
+            None: SensorDeviceInfo(
+                name="IO Series 6/7 48BE",
+                model="IO Series 6/7",
+                manufacturer="Oral-B",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="mode", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="mode", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="time", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="time", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorValue(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                name="Number " "of " "sectors",
+                native_value=4,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                name="Sector " "Timer",
+                native_value=0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-63,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector", device_id=None),
+                name="Sector",
+                native_value="sector " "1",
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                name="Toothbrush " "State",
+                native_value="idle",
+            ),
+            DeviceKey(key="mode", device_id=None): SensorValue(
+                device_key=DeviceKey(key="mode", device_id=None),
+                name="Mode",
+                native_value="daily clean",
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorValue(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                name="Pressure",
+                native_value="normal",
+            ),
+            DeviceKey(key="time", device_id=None): SensorValue(
+                device_key=DeviceKey(key="time", device_id=None),
+                name="Time",
+                native_value=0,
+            ),
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="brushing", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="brushing", device_id=None), device_class=None
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="brushing", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="brushing", device_id=None),
+                name="Brushing",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
+def test_io_series_6_sensitive_mode():
+    parser = OralBBluetoothDeviceData()
+    service_info = ORALB_IO_SERIES_6_SENSITIVE
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title="IO Series 6/7 48BE",
+        devices={
+            None: SensorDeviceInfo(
+                name="IO Series 6/7 48BE",
+                model="IO Series 6/7",
+                manufacturer="Oral-B",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="mode", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="mode", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="time", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="time", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorValue(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                name="Number " "of " "sectors",
+                native_value=4,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                name="Sector " "Timer",
+                native_value=0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-63,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector", device_id=None),
+                name="Sector",
+                native_value="sector " "1",
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                name="Toothbrush " "State",
+                native_value="idle",
+            ),
+            DeviceKey(key="mode", device_id=None): SensorValue(
+                device_key=DeviceKey(key="mode", device_id=None),
+                name="Mode",
+                native_value="sensitive",
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorValue(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                name="Pressure",
+                native_value="normal",
+            ),
+            DeviceKey(key="time", device_id=None): SensorValue(
+                device_key=DeviceKey(key="time", device_id=None),
+                name="Time",
+                native_value=0,
+            ),
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="brushing", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="brushing", device_id=None), device_class=None
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="brushing", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="brushing", device_id=None),
+                name="Brushing",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
+def test_io_series_6_gum_care_mode():
+    parser = OralBBluetoothDeviceData()
+    service_info = ORALB_IO_SERIES_6_GUM_CARE
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title="IO Series 6/7 48BE",
+        devices={
+            None: SensorDeviceInfo(
+                name="IO Series 6/7 48BE",
+                model="IO Series 6/7",
+                manufacturer="Oral-B",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="mode", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="mode", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="time", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="time", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorValue(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                name="Number " "of " "sectors",
+                native_value=4,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                name="Sector " "Timer",
+                native_value=0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-63,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector", device_id=None),
+                name="Sector",
+                native_value="sector " "1",
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                name="Toothbrush " "State",
+                native_value="idle",
+            ),
+            DeviceKey(key="mode", device_id=None): SensorValue(
+                device_key=DeviceKey(key="mode", device_id=None),
+                name="Mode",
+                native_value="gum care",
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorValue(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                name="Pressure",
+                native_value="normal",
+            ),
+            DeviceKey(key="time", device_id=None): SensorValue(
+                device_key=DeviceKey(key="time", device_id=None),
+                name="Time",
+                native_value=0,
+            ),
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="brushing", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="brushing", device_id=None), device_class=None
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="brushing", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="brushing", device_id=None),
+                name="Brushing",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
+def test_io_series_6_whiten_mode():
+    parser = OralBBluetoothDeviceData()
+    service_info = ORALB_IO_SERIES_6_WHITEN
+    result = parser.update(service_info)
+    assert result == SensorUpdate(
+        title="IO Series 6/7 48BE",
+        devices={
+            None: SensorDeviceInfo(
+                name="IO Series 6/7 48BE",
+                model="IO Series 6/7",
+                manufacturer="Oral-B",
+                sw_version=None,
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="sector", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="mode", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="mode", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+            DeviceKey(key="time", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="time", device_id=None),
+                device_class=None,
+                native_unit_of_measurement=None,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="number_of_sectors", device_id=None): SensorValue(
+                device_key=DeviceKey(key="number_of_sectors", device_id=None),
+                name="Number " "of " "sectors",
+                native_value=4,
+            ),
+            DeviceKey(key="sector_timer", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector_timer", device_id=None),
+                name="Sector " "Timer",
+                native_value=0,
+            ),
+            DeviceKey(key="signal_strength", device_id=None): SensorValue(
+                device_key=DeviceKey(key="signal_strength", device_id=None),
+                name="Signal " "Strength",
+                native_value=-63,
+            ),
+            DeviceKey(key="sector", device_id=None): SensorValue(
+                device_key=DeviceKey(key="sector", device_id=None),
+                name="Sector",
+                native_value="sector " "1",
+            ),
+            DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
+                device_key=DeviceKey(key="toothbrush_state", device_id=None),
+                name="Toothbrush " "State",
+                native_value="idle",
+            ),
+            DeviceKey(key="mode", device_id=None): SensorValue(
+                device_key=DeviceKey(key="mode", device_id=None),
+                name="Mode",
+                native_value="whiten",
+            ),
+            DeviceKey(key="pressure", device_id=None): SensorValue(
+                device_key=DeviceKey(key="pressure", device_id=None),
+                name="Pressure",
+                native_value="normal",
+            ),
+            DeviceKey(key="time", device_id=None): SensorValue(
+                device_key=DeviceKey(key="time", device_id=None),
+                name="Time",
+                native_value=0,
+            ),
+        },
+        binary_entity_descriptions={
+            DeviceKey(key="brushing", device_id=None): BinarySensorDescription(
+                device_key=DeviceKey(key="brushing", device_id=None), device_class=None
+            )
+        },
+        binary_entity_values={
+            DeviceKey(key="brushing", device_id=None): BinarySensorValue(
+                device_key=DeviceKey(key="brushing", device_id=None),
+                name="Brushing",
+                native_value=False,
+            )
+        },
+        events={},
+    )
+
+
 def test_io_series_7():
     parser = OralBBluetoothDeviceData()
     service_info = ORALB_IO_SERIES_7
     result = parser.update(service_info)
     assert result == SensorUpdate(
-        title="IO Series 7/8 48BE",
+        title="IO Series 6/7 48BE",
         devices={
             None: SensorDeviceInfo(
-                name="IO Series 7/8 48BE",
-                model="IO Series 7/8",
+                name="IO Series 6/7 48BE",
+                model="IO Series 6/7",
                 manufacturer="Oral-B",
                 sw_version=None,
                 hw_version=None,


### PR DESCRIPTION
Adding support for IO 6 for Issue [#85115](https://github.com/home-assistant/core/issues/85115) in Home Assistant.

The IO 6 and the IO 7 are identical brushes, the only real difference is the charger for the IO 7, otherwise they have the same features and probably the same internals other than the battery if I had to guess. Therefore it makes sense to group the IO 6 and 7 instead of 7 and 8.

When it comes to brush pressure, after doing some testing and looking at the manufacture data, there is no differentiation between normal and low pressure.

Here is the manufacture data I stored - perhaps someone else can figure something out with it

~~~
ORALB_IO_SERIES_6_NO_PRESSURE_LIST = [
    b'\x062k\x08r\x00\x00\x01\x01\x00\x04',
    b'\x062k\x03r\x00\x07\x01\x01\x00\x04',
    b'\x062k\x03r\x00\x0c\x03\x01\x00\x04',
    b'\x062k\x03r\x00!\x03\x02\x00\x04',
    b'\x062k\x03r\x00\x04\x03\x01\x00\x04',
    b'\x062k\x03r\x00\x0f\x03\x01\x00\x04',
    b'\x062k\x03r\x00$\x03\x02\x00\x04',
    b'\x062k\x03r\x00.\x03\x02\x00\x04',
    b'\x062k\x03r\x009\x03\x02\x00\x04',
    b'\x062k\x03r\x011\x03\x07\x00\x04',
    b"\x062k\x03r\x01'\x03\x07\x00\x04"
]

ORALB_IO_SERIES_6_NORMAL_PRESSURE_LIST = [
    b'\x062k\x03r\x007\x03\x02\x00\x04',
    b'\x062k\x03r\x01\x05\x03\x03\x00\x04',
    b'\x062k\x03r\x01\x0f\x03\x03\x00\x04',
    b'\x062k\x03r\x01\x1a\x03\x03\x00\x04',
    b'\x062k\x03r\x01\r\x03\x03\x00\x04',
    b'\x062k\x03r\x01\x15\x03\x03\x00\x04'
]

ORALB_IO_SERIES_6_HIGH_PRESSURE_LIST = [
    b'\x062k\x03\xb2\x00\x0c\x03\x01\x00\x04',
    b'\x062k\x03\xb2\x00\x1a\x03\x01\x00\x04',
    b'\x062k\x03\xb2\x00!\x03\x02\x00\x04'

]
~~~

I added Tongue Clean for issue [#83188](https://github.com/home-assistant/core/issues/83188) in Home Assistant.

There were a few issues in regard to IO 9 appearing as an IO8. it seems both IO8 and IO9 can have device data of b'\x061\x19' [issue showing io9](https://github.com/home-assistant/core/issues/82939) and [issue showing io8](https://github.com/Bluetooth-Devices/oralb-ble/issues/24), but the IO 9 can also have b'\x061\x16' according to this [issue](https://github.com/home-assistant/core/issues/81159)

There is a chance someone was mistaken on what model they have? Or they device data is just identical. 


Which leads to the next problem, if we had sector data, it would be easy to differentiate between the io8 and the io9, as the io9 has 16 zones and the io8 has 6 zones. I believe that sector data is completely wrong. Again, according to #24 their manufacture data ends with b'\x00' implying there are 0 zones. In fact, every tooth brush seems to report having 4 sectors, when in reality most have 6. I think num_sectors should be removed.  However, if the manufacture data for the io8 is not a fluke, we can use that information to differentiate between io 9 and io 8 - even if we don't know what it means.

I can split some of these things into new issues if you would like