### PR TITLE
feat: rework sectors, fix pressures, and fix misidentification of IO 9 as 8

### DIFF
--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -83,6 +83,7 @@ IO_SERIES_MODES = {
     5: "super sensitive",
     6: "tongue cleaning",
     8: "settings",
+    9: "off",
 }
 
 

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -252,7 +252,7 @@ class OralBBluetoothDeviceData(BluetoothData):
         tb_sector = SECTOR_MAP.get(sector, f"unknown sector code {sector}")
 
         self.update_sensor(str(OralBSensor.TIME), None, time, None, "Time")
-        if time == 0 and (tb_state != "running"):
+        if time == 0 and tb_state != "running":
             """When starting up, sector is not accurate."""
             self.update_sensor(
                 str(OralBSensor.SECTOR), None, "no sector", None, "Sector"

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -253,7 +253,7 @@ class OralBBluetoothDeviceData(BluetoothData):
 
         self.update_sensor(str(OralBSensor.TIME), None, time, None, "Time")
         if time == 0 and tb_state != "running":
-            """When starting up, sector is not accurate."""
+            # When starting up, sector is not accurate.
             self.update_sensor(
                 str(OralBSensor.SECTOR), None, "no sector", None, "Sector"
             )

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -252,7 +252,7 @@ class OralBBluetoothDeviceData(BluetoothData):
         tb_sector = SECTOR_MAP.get(sector, f"unknown sector code {sector}")
 
         self.update_sensor(str(OralBSensor.TIME), None, time, None, "Time")
-        if time == 0 and (state == 2 or state == 8):
+        if time == 0 and (tb_state != "running"):
             """When starting up, sector is not accurate."""
             self.update_sensor(
                 str(OralBSensor.SECTOR), None, "no sector", None, "Sector"

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -39,10 +39,11 @@ class Models(Enum):
 
     Pro6000 = auto()
     TriumphV2 = auto()
+    IOSeries4 = auto()
+    IOSeries67 = auto()
     IOSeries8 = auto()
     IOSeries9 = auto()
-    IOSeries67 = auto()
-    IOSeries4 = auto()
+    IOSeries89 = auto()
     SmartSeries4000 = auto()
     SmartSeries6000 = auto()
     SmartSeries7000 = auto()
@@ -88,6 +89,10 @@ IO_SERIES_MODES = {
 DEVICE_TYPES = {
     Models.Pro6000: ModelDescription("Pro 6000", SMART_SERIES_MODES),
     Models.TriumphV2: ModelDescription("Triumph V2", SMART_SERIES_MODES),
+    Models.IOSeries4: ModelDescription(
+        device_type="IO Series 4",
+        modes=IO_SERIES_MODES,
+    ),
     Models.IOSeries67: ModelDescription(
         device_type="IO Series 6/7",
         modes=IO_SERIES_MODES,
@@ -100,8 +105,8 @@ DEVICE_TYPES = {
         device_type="IO Series 9",
         modes=IO_SERIES_MODES,
     ),
-    Models.IOSeries4: ModelDescription(
-        device_type="IO Series 4",
+    Models.IOSeries89: ModelDescription(
+        device_type="IO Series 8/9",
         modes=IO_SERIES_MODES,
     ),
     Models.SmartSeries4000: ModelDescription(
@@ -175,8 +180,8 @@ BYTES_TO_MODEL = {
     b'\x03"\x0c': Models.SmartSeries8000,
     b"\x03!\x0b": Models.SmartSeries9000,
     b"\x03!\x0c": Models.SmartSeries9000,
-    b"\x061\x19": Models.IOSeries8,
-    b"\x061\x16": Models.IOSeries9,
+    b"\x061\x19": Models.IOSeries89,
+    b"\x061\x16": Models.IOSeries89,
     b"\x02\x02\x06": Models.TriumphV2,
     b"\x01\x02\x05": Models.Pro6000,
 }

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -182,8 +182,23 @@ BYTES_TO_MODEL = {
 }
 
 SECTOR_MAP = {
-    254: "last sector",
-    255: "no sector",
+    1: "sector 1",
+    9: "sector 1",
+    2: "sector 2",
+    10: "sector 2",
+    3: "sector 3",
+    11: "sector 3",
+    19: "sector 3",
+    27: "sector 3",
+    7: "sector 4",
+    15: "sector 4",
+    31: "sector 4",
+    39: "sector 4",
+    41: "success",
+    42: "success",
+    43: "success",
+    47: "success",
+    55: "success",
 }
 
 
@@ -228,10 +243,16 @@ class OralBBluetoothDeviceData(BluetoothData):
         tb_state = STATES.get(state, f"unknown state {state}")
         tb_mode = modes.get(mode, f"unknown mode {mode}")
         tb_pressure = PRESSURE.get(pressure, f"unknown pressure {pressure}")
-        tb_sector = SECTOR_MAP.get(sector, f"sector {sector}")
+        tb_sector = SECTOR_MAP.get(sector, f"unknown sector code {sector}")
 
         self.update_sensor(str(OralBSensor.TIME), None, time, None, "Time")
-        self.update_sensor(str(OralBSensor.SECTOR), None, tb_sector, None, "Sector")
+        if time == 0 and (state == 2 or state == 8):
+            """When starting up, sector is not accurate."""
+            self.update_sensor(
+                str(OralBSensor.SECTOR), None, "no sector", None, "Sector"
+            )
+        else:
+            self.update_sensor(str(OralBSensor.SECTOR), None, tb_sector, None, "Sector")
         if no_of_sectors is not None:
             self.update_sensor(
                 str(OralBSensor.NUMBER_OF_SECTORS),

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -126,7 +126,6 @@ DEVICE_TYPES = {
     ),
 }
 
-
 STATES = {
     0: "unknown",
     1: "initializing",
@@ -154,8 +153,11 @@ PRESSURE = {
     56: "power button pressed",
     114: "normal",
     118: "button pressed",
+    122: "power button pressed",
     178: "high",
     146: "high",
+    182: "button pressed",
+    186: "power button pressed",
     192: "high",
     240: "high",
     242: "high",
@@ -178,6 +180,7 @@ BYTES_TO_MODEL = {
     b"\x02\x02\x06": Models.TriumphV2,
     b"\x01\x02\x05": Models.Pro6000,
 }
+
 SECTOR_MAP = {
     254: "last sector",
     255: "no sector",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1741,11 +1741,11 @@ def test_io_series_9():
     service_info = ORALB_IO_SERIES_9
     result = parser.update(service_info)
     assert result == SensorUpdate(
-        title="IO Series 9 48BE",
+        title="IO Series 8/9 48BE",
         devices={
             None: SensorDeviceInfo(
-                name="IO Series 9 48BE",
-                model="IO Series 9",
+                name="IO Series 8/9 48BE",
+                model="IO Series 8/9",
                 manufacturer="Oral-B",
                 sw_version=None,
                 hw_version=None,
@@ -2871,11 +2871,11 @@ def test_io_series_8():
     service_info = ORALB_IO_SERIES_8
     result = parser.update(service_info)
     assert result == SensorUpdate(
-        title="IO Series 8 48BE",
+        title="IO Series 8/9 48BE",
         devices={
             None: SensorDeviceInfo(
-                name="IO Series 8 48BE",
-                model="IO Series 8",
+                name="IO Series 8/9 48BE",
+                model="IO Series 8/9",
                 manufacturer="Oral-B",
                 sw_version=None,
                 hw_version=None,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -312,7 +312,7 @@ def test_dataset_1():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="number_of_sectors", device_id=None): SensorValue(
                 device_key=DeviceKey(key="number_of_sectors", device_id=None),
@@ -777,7 +777,7 @@ def test_io_series_6():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
                 device_key=DeviceKey(key="toothbrush_state", device_id=None),
@@ -892,7 +892,7 @@ def test_io_series_6_daily_clean_mode():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
                 device_key=DeviceKey(key="toothbrush_state", device_id=None),
@@ -1007,7 +1007,7 @@ def test_io_series_6_sensitive_mode():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
                 device_key=DeviceKey(key="toothbrush_state", device_id=None),
@@ -1122,7 +1122,7 @@ def test_io_series_6_gum_care_mode():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
                 device_key=DeviceKey(key="toothbrush_state", device_id=None),
@@ -1237,7 +1237,7 @@ def test_io_series_6_whiten_mode():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
                 device_key=DeviceKey(key="toothbrush_state", device_id=None),
@@ -1712,7 +1712,7 @@ def test_9000_black_series():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "1",
+                native_value="no " "sector",
             ),
             DeviceKey(key="toothbrush_state", device_id=None): SensorValue(
                 device_key=DeviceKey(key="toothbrush_state", device_id=None),
@@ -1802,7 +1802,7 @@ def test_io_series_9():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "2",
+                native_value="no " "sector",
             ),
             DeviceKey(key="time", device_id=None): SensorValue(
                 device_key=DeviceKey(key="time", device_id=None),
@@ -2047,7 +2047,7 @@ def test_triumph_v2():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "15",
+                native_value="no " "sector",
             ),
             DeviceKey(key="pressure", device_id=None): SensorValue(
                 device_key=DeviceKey(key="pressure", device_id=None),
@@ -2732,7 +2732,7 @@ def test_genius_8000():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "15",
+                native_value="no " "sector",
             ),
         },
         binary_entity_descriptions={
@@ -2837,7 +2837,7 @@ def test_genius_8000_high_pressure():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "4",
+                native_value="unknown sector code " "4",
             ),
             DeviceKey(key="time", device_id=None): SensorValue(
                 device_key=DeviceKey(key="time", device_id=None),
@@ -2947,7 +2947,7 @@ def test_io_series_8():
             DeviceKey(key="sector", device_id=None): SensorValue(
                 device_key=DeviceKey(key="sector", device_id=None),
                 name="Sector",
-                native_value="sector " "7",
+                native_value="no " "sector",
             ),
             DeviceKey(key="time", device_id=None): SensorValue(
                 device_key=DeviceKey(key="time", device_id=None),


### PR DESCRIPTION
Okay this one is kind of spread out. I tired to make sure lint wont get made at me, but we will see. 

## Pressures
* When you push a button while you have high pressure, it was previously giving an unknown pressure, this has been resolved to give the correct button pressed.
* pressure 122 is hitting a power button ( at least on my io series)
* relating to issue [85115](https://github.com/home-assistant/core/issues/85115)

## Sectors
* this should potentially be renamed, as people seem to be confused into thinking this means what sector of your mouth you are brushing, in reality, it is what sector of the 2 minute clock you are on, first 30 seconds, 2nd 30 seconds, etc.
* When you pause, the sector will go up by 8, 16, or 24 and then continue counting sectors from there.
* It is possible for a user to continue brushing after succeeding, 41 -> 43 represent the 3 extra sectors after
a successful brushing session.
* succeeding is classified as stopping the toothbrush after the 2 minute mark
* Oddly enough, Sector 4 is marked as 7.
* relating to issue [85115](https://github.com/home-assistant/core/issues/85115)

## Io 8/9
* If we look at issues [#82939](https://github.com/home-assistant/core/issues/82939) #24 , and [81159](https://github.com/home-assistant/core/issues/81159) we can see io 8/9 device bytes have some overlap. there is a potential solution by using the last bytes for io 8, but we need more data to be sure if that is a real solution.

## Offline State for io series
* Multiple issues such as [81901](https://github.com/home-assistant/core/issues/81901) discuss wishing that the sensors didn't go 'unavailable' after completing. through my limited research, it seems like `bluetooth.async_track_unavailable` may be the solution in home assistant. Once the device goes unavailable - set all of the states to 'offline' or 0 or something similar. This offline state just allows that functionality to happen as there will be a state that can be set.  I haven't even attempted this(but I plan to try) because developing on core seems like it will be a challenge, so I am not sure if it is a real solution, but I thought I would add in the functionality that is needed here, as it wont cause any kinds of issues.