### PR TITLE
fix: identification of Genius X and 10000

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,11 +39,11 @@ repos:
       - id: pyupgrade
         args: [--py37-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -194,7 +194,8 @@ ORALB_MANUFACTURER = 0x00DC
 
 BYTES_TO_MODEL = {
     b"\x062k": Models.IOSeries67,
-    b"\x074": Models.IOSeries4,
+    b"\x074\x0c": Models.IOSeries4,
+    b"\x074\x1a": Models.IOSeries4,
     b"\x03V\x04": Models.SmartSeries4000,
     b"\x04'\r": Models.SmartSeries6000,
     b'\x03"\x0c': Models.SmartSeries8000,

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -194,7 +194,7 @@ ORALB_MANUFACTURER = 0x00DC
 
 BYTES_TO_MODEL = {
     b"\x062k": Models.IOSeries67,
-    b"\x074\x0c": Models.IOSeries4,
+    b"\x074": Models.IOSeries4,
     b"\x03V\x04": Models.SmartSeries4000,
     b"\x04'\r": Models.SmartSeries6000,
     b'\x03"\x0c': Models.SmartSeries8000,

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -62,6 +62,7 @@ class Models(Enum):
     SmartSeries7000 = auto()
     SmartSeries8000 = auto()
     SmartSeries9000 = auto()
+    GeniusX = auto()
 
 
 @dataclass
@@ -140,9 +141,10 @@ DEVICE_TYPES = {
         modes=SMART_SERIES_MODES,
     ),
     Models.SmartSeries9000: ModelDescription(
-        device_type="Smart Series 9000",
+        device_type="Smart Series 9000/10000",
         modes=SMART_SERIES_MODES,
     ),
+    Models.GeniusX: ModelDescription(device_type="Genius X", modes=SMART_SERIES_MODES),
 }
 
 STATES = {
@@ -205,6 +207,7 @@ BYTES_TO_MODEL = {
     b"\x061\x16": Models.IOSeries89,
     b"\x02\x02\x06": Models.TriumphV2,
     b"\x01\x02\x05": Models.Pro6000,
+    b"\x04q\x04": Models.GeniusX,
 }
 
 SECTOR_MAP = {

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1515,11 +1515,11 @@ def test_9000_series():
     service_info = ORALB_9000_SERIES
     result = parser.update(service_info)
     assert result == SensorUpdate(
-        title="Smart Series 9000 48BE",
+        title="Smart Series 9000/10000 48BE",
         devices={
             None: SensorDeviceInfo(
-                name="Smart Series 9000 48BE",
-                model="Smart Series 9000",
+                name="Smart Series 9000/10000 48BE",
+                model="Smart Series 9000/10000",
                 manufacturer="Oral-B",
                 sw_version=None,
                 hw_version=None,
@@ -1630,11 +1630,11 @@ def test_9000_black_series():
     service_info = ORALB_9000_BLACK_SERIES
     result = parser.update(service_info)
     assert result == SensorUpdate(
-        title="Smart Series 9000 48BE",
+        title="Smart Series 9000/10000 48BE",
         devices={
             None: SensorDeviceInfo(
-                name="Smart Series 9000 48BE",
-                model="Smart Series 9000",
+                name="Smart Series 9000/10000 48BE",
+                model="Smart Series 9000/10000",
                 manufacturer="Oral-B",
                 sw_version=None,
                 hw_version=None,


### PR DESCRIPTION
Genius x: https://community.home-assistant.io/t/oral-b-integration-entities/485017/27?u=lash-l
10,000: https://github.com/home-assistant/core/issues/86242

Side thought: maybe it is worth changing the default identification to "Unknown toothbrush" rather than the 7000 series. 