### PR TITLE
fix: add retries to polling functionality

### DIFF
--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -343,7 +343,7 @@ class OralBBluetoothDeviceData(BluetoothData):
             pressure_char = client.services.get_characteristic(CHARACTERISTIC_PRESSURE)
             pressure_payload = await client.read_gatt_char(pressure_char)
         except BleakError as err:
-            _LOGGER.debug(f"Reading gatt characters failed with err: {err}")
+            _LOGGER.warning(f"Reading gatt characters failed with err: {err}")
         else:
             tb_pressure = ACTIVE_CONNECTION_PRESSURE.get(
                 pressure_payload[0], f"unknown pressure {pressure_payload[0]}"

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -342,6 +342,9 @@ class OralBBluetoothDeviceData(BluetoothData):
             battery_payload = await client.read_gatt_char(battery_char)
             pressure_char = client.services.get_characteristic(CHARACTERISTIC_PRESSURE)
             pressure_payload = await client.read_gatt_char(pressure_char)
+        except BleakError as err:
+            _LOGGER.debug(f"Reading gatt characters failed with err: {err}")
+        else:
             tb_pressure = ACTIVE_CONNECTION_PRESSURE.get(
                 pressure_payload[0], f"unknown pressure {pressure_payload[0]}"
             )
@@ -356,8 +359,6 @@ class OralBBluetoothDeviceData(BluetoothData):
                 "Battery",
             )
             _LOGGER.debug("Successfully read active gatt characters")
-        except BleakError as err:
-            _LOGGER.debug(f"Reading gatt characters failed with err: {err}")
         finally:
             await client.disconnect()
             _LOGGER.debug("Disconnected from active bluetooth client")


### PR DESCRIPTION
this PR does two things 

1) adds a few extra logs to help debug https://github.com/home-assistant/core/issues/88009

2) potentially I am being silly here, but I think the code to get payloads was problematic, as if it failed, it would still attempt to get it as it was outside of the try catch and after finally.

I don't know if the except BleakError is worth it, as I know the connector also excepts for bleakerrors.