### PR TITLE
fix: decode sectors 5 and 6 for 6-sector brushes (IO Series 10)

### DIFF
--- a/docs/source/wire-format.md
+++ b/docs/source/wire-format.md
@@ -25,19 +25,19 @@ opening a GATT connection and reading the relevant characteristic.
 The parser indexes the payload as raw bytes. The table below uses
 zero-based byte offsets.
 
-| Byte | Field              | Notes                                                                                                             |
-| ---: | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
-|    0 | Protocol version   | `1` (D36 / Pro 6000), `2` (Triumph v2 / early D36), `3` (D601 / D701), `4` (D700), `6` (IO Series), `7` (IO 4).   |
-|    1 | Model identifier   | Looked up in `MODEL_ID_TO_MODEL`. Unknown IDs fall back to `Models.Unknown` (uses `SMART_SERIES_MODES`).          |
-|    2 | Reserved           | Not interpreted by this parser. Believed to be firmware/hardware revision.                                        |
-|    3 | Toothbrush state   | Decoded via `STATES`. `3` is the only value that means "actively brushing" — drives the `brushing` binary sensor. |
-|    4 | Pressure           | Decoded via `PRESSURE`. See [pressure bit-encoding](#pressure-byte-bit-encoding) below.                           |
-|    5 | Brush-time minutes | High byte of the elapsed brushing time. Combined with byte 6 as `data[5] * 60 + data[6]` seconds.                 |
-|    6 | Brush-time seconds | Low component of the elapsed brushing time, in seconds within the current minute.                                 |
-|    7 | Mode               | Decoded via the per-model `modes` dict (`SMART_SERIES_MODES` or `IO_SERIES_MODES`).                               |
+| Byte | Field              | Notes                                                                                                                                              |
+| ---: | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+|    0 | Protocol version   | `1` (D36 / Pro 6000), `2` (Triumph v2 / early D36), `3` (D601 / D701), `4` (D700), `6` (IO Series), `7` (IO 4).                                    |
+|    1 | Model identifier   | Looked up in `MODEL_ID_TO_MODEL`. Unknown IDs fall back to `Models.Unknown` (uses `SMART_SERIES_MODES`).                                           |
+|    2 | Reserved           | Not interpreted by this parser. Believed to be firmware/hardware revision.                                                                         |
+|    3 | Toothbrush state   | Decoded via `STATES`. `3` is the only value that means "actively brushing" — drives the `brushing` binary sensor.                                  |
+|    4 | Pressure           | Decoded via `PRESSURE`. See [pressure bit-encoding](#pressure-byte-bit-encoding) below.                                                            |
+|    5 | Brush-time minutes | High byte of the elapsed brushing time. Combined with byte 6 as `data[5] * 60 + data[6]` seconds.                                                  |
+|    6 | Brush-time seconds | Low component of the elapsed brushing time, in seconds within the current minute.                                                                  |
+|    7 | Mode               | Decoded via the per-model `modes` dict (`SMART_SERIES_MODES` or `IO_SERIES_MODES`).                                                                |
 |    8 | Sector code        | Decoded via `_decode_sector`. See [sector bit-encoding](#sector-byte-bit-encoding). Reported as `"no sector"` whenever the state is not `running`. |
-|    9 | Sector timer       | Seconds elapsed in the current sector. Present only on length-11 payloads.                                        |
-|   10 | Number of sectors  | How many sectors the brush is configured for (commonly `4` or `6`). Present only on length-11 payloads.           |
+|    9 | Sector timer       | Seconds elapsed in the current sector. Present only on length-11 payloads.                                                                         |
+|   10 | Number of sectors  | How many sectors the brush is configured for (commonly `4` or `6`). Present only on length-11 payloads.                                            |
 
 ### Pressure byte bit-encoding
 

--- a/docs/source/wire-format.md
+++ b/docs/source/wire-format.md
@@ -35,7 +35,7 @@ zero-based byte offsets.
 |    5 | Brush-time minutes | High byte of the elapsed brushing time. Combined with byte 6 as `data[5] * 60 + data[6]` seconds.                 |
 |    6 | Brush-time seconds | Low component of the elapsed brushing time, in seconds within the current minute.                                 |
 |    7 | Mode               | Decoded via the per-model `modes` dict (`SMART_SERIES_MODES` or `IO_SERIES_MODES`).                               |
-|    8 | Sector code        | Decoded via `SECTOR_MAP`. Reported as `"no sector"` whenever the state is not `running`.                          |
+|    8 | Sector code        | Decoded via `_decode_sector`. See [sector bit-encoding](#sector-byte-bit-encoding). Reported as `"no sector"` whenever the state is not `running`. |
 |    9 | Sector timer       | Seconds elapsed in the current sector. Present only on length-11 payloads.                                        |
 |   10 | Number of sectors  | How many sectors the brush is configured for (commonly `4` or `6`). Present only on length-11 payloads.           |
 
@@ -55,6 +55,24 @@ The `PRESSURE` lookup table is not a flat list of magic numbers — it is a
 When both a pressure level and a button event are set, the button-event
 label wins in the flattened string the parser emits (this is by design —
 the active-button label is the more actionable signal for the user).
+
+### Sector byte bit-encoding
+
+Like the pressure byte, byte 8 packs two independent fields:
+
+- **Low three bits** (`sector & 0x07`) encode the quadrant index:
+  - `0` — no quadrant
+  - `1`–`6` — that quadrant
+  - `7` — a "last quadrant" sentinel; its real number is the brush's sector
+    count (byte 10). Firmware that does not report a count (`0` or a length-9
+    payload) falls back to the historical four-sector assumption.
+- **Upper bits** (`sector >> 3`) are a display flag indicating which feedback
+  face the handle shows. They do not change the quadrant and are masked off.
+
+This replaces the previous hand-built `SECTOR_MAP`, which only covered
+4-sector brushes: it returned `"unknown sector code 5"` for sector 5 and
+reused `"sector 4"` for the last-quadrant sentinel, so 6-sector brushes
+(IO Series 10) mis-reported sectors 5 and 6.
 
 ### Reading an example
 

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -217,27 +217,10 @@ def _decode_sector(sector: int, no_of_sectors: int | None) -> str:
     """Decode the sector code (manufacturer data byte 8).
 
     The low three bits hold the quadrant index: ``1``-``6`` for a concrete
-    quadrant, ``7`` is a "last quadrant" sentinel and ``0`` means no quadrant.
-    The upper bits are a display flag (which feedback face the handle shows)
-    and do not change the quadrant, so they are masked off.
-
-    Because ``7`` only marks the *last* quadrant, its real number depends on
-    how many sectors the brush is configured for (byte 10). Firmware that does
-    not report a sector count (``no_of_sectors`` 0 or absent) falls back to the
-    historical four-sector assumption.
-
-    This replaces the old hand-built lookup table, which only covered 4-sector
-    brushes: it returned ``"unknown sector code 5"`` for sector 5 and wrongly
-    reused ``"sector 4"`` for the last-quadrant sentinel on 6-sector brushes
-    (e.g. IO Series 10).
-
-    The old table also mapped a few bytes (41, 42, 43, 47, 55) to ``"success"``.
-    Those carry the end-of-session feedback face in the upper bits and only
-    occur in non-running frames, which #151 already reports as ``"no sector"``
-    regardless of the byte -- so ``"success"`` was already unreachable through
-    the sensor and is intentionally not reproduced here. A finished session is
-    better detected from the ``running`` state ending together with the elapsed
-    brushing time than from a transient sector value.
+    quadrant, ``0`` means no quadrant, and ``7`` is a "last quadrant"
+    sentinel whose real number is the sector count (byte 10), falling back
+    to 4 when the count is absent. The upper bits are a display flag and
+    are masked off.
     """
     quadrant = sector & 0x07
     if quadrant == 0:

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -230,6 +230,14 @@ def _decode_sector(sector: int, no_of_sectors: int | None) -> str:
     brushes: it returned ``"unknown sector code 5"`` for sector 5 and wrongly
     reused ``"sector 4"`` for the last-quadrant sentinel on 6-sector brushes
     (e.g. IO Series 10).
+
+    The old table also mapped a few bytes (41, 42, 43, 47, 55) to ``"success"``.
+    Those carry the end-of-session feedback face in the upper bits and only
+    occur in non-running frames, which #151 already reports as ``"no sector"``
+    regardless of the byte -- so ``"success"`` was already unreachable through
+    the sensor and is intentionally not reproduced here. A finished session is
+    better detected from the ``running`` state ending together with the elapsed
+    brushing time than from a transient sector value.
     """
     quadrant = sector & 0x07
     if quadrant == 0:

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -212,26 +212,32 @@ MODEL_ID_TO_MODEL: dict[int, Models] = {
     119: Models.D706,  # D706 5_MODE_CHINA
 }
 
-SECTOR_MAP = {
-    1: "sector 1",
-    9: "sector 1",
-    2: "sector 2",
-    10: "sector 2",
-    3: "sector 3",
-    11: "sector 3",
-    19: "sector 3",
-    27: "sector 3",
-    4: "sector 4",
-    7: "sector 4",
-    15: "sector 4",
-    31: "sector 4",
-    39: "sector 4",
-    41: "success",
-    42: "success",
-    43: "success",
-    47: "success",
-    55: "success",
-}
+
+def _decode_sector(sector: int, no_of_sectors: int | None) -> str:
+    """Decode the sector code (manufacturer data byte 8).
+
+    The low three bits hold the quadrant index: ``1``-``6`` for a concrete
+    quadrant, ``7`` is a "last quadrant" sentinel and ``0`` means no quadrant.
+    The upper bits are a display flag (which feedback face the handle shows)
+    and do not change the quadrant, so they are masked off.
+
+    Because ``7`` only marks the *last* quadrant, its real number depends on
+    how many sectors the brush is configured for (byte 10). Firmware that does
+    not report a sector count (``no_of_sectors`` 0 or absent) falls back to the
+    historical four-sector assumption.
+
+    This replaces the old hand-built lookup table, which only covered 4-sector
+    brushes: it returned ``"unknown sector code 5"`` for sector 5 and wrongly
+    reused ``"sector 4"`` for the last-quadrant sentinel on 6-sector brushes
+    (e.g. IO Series 10).
+    """
+    quadrant = sector & 0x07
+    if quadrant == 0:
+        return "no sector"
+    if quadrant == 7:
+        count = (no_of_sectors or 0) & 0x07
+        return f"sector {count or 4}"
+    return f"sector {quadrant}"
 
 
 class OralBBluetoothDeviceData(BluetoothData):
@@ -279,7 +285,7 @@ class OralBBluetoothDeviceData(BluetoothData):
         tb_state = STATES.get(state, f"unknown state {state}")
         tb_mode = self.brush_modes.get(mode, f"unknown mode {mode}")
         tb_pressure = PRESSURE.get(pressure, f"unknown pressure {pressure}")
-        tb_sector = SECTOR_MAP.get(sector, f"unknown sector code {sector}")
+        tb_sector = _decode_sector(sector, no_of_sectors)
 
         self.update_sensor(str(OralBSensor.TIME), None, brush_time, None, "Time")
         if tb_state != "running":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3358,12 +3358,12 @@ def _sector_value(service_info: BluetoothServiceInfo) -> str:
     return result.entity_values[_SECTOR_KEY].native_value
 
 
-def test_io_series_10_sector_5():
+def test_io_series_10_sector_5() -> None:
     """Sector 5 was previously reported as 'unknown sector code 5'."""
     assert _sector_value(ORALB_IO_SERIES_10_SECTOR_5) == "sector 5"
 
 
-def test_io_series_10_sector_6():
+def test_io_series_10_sector_6() -> None:
     """The last-quadrant sentinel (0x07) is sector 6 on a 6-sector brush."""
     parser = OralBBluetoothDeviceData()
     result = parser.update(ORALB_IO_SERIES_10_SECTOR_6)
@@ -3371,11 +3371,11 @@ def test_io_series_10_sector_6():
     assert result.entity_values[_NUMBER_OF_SECTORS_KEY].native_value == 6
 
 
-def test_io_series_10_sector_4_with_display_flag():
+def test_io_series_10_sector_4_with_display_flag() -> None:
     """Upper display-flag bits must not change the decoded quadrant."""
     assert _sector_value(ORALB_IO_SERIES_10_SECTOR_4_FLAGGED) == "sector 4"
 
 
-def test_io_series_last_quadrant_without_sector_count():
+def test_io_series_last_quadrant_without_sector_count() -> None:
     """Firmware that omits the sector count falls back to four sectors."""
     assert _sector_value(ORALB_IO_SERIES_NO_COUNT_RUNNING) == "sector 4"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3291,3 +3291,91 @@ def test_poll_needed_not_brushing_after_long_idle_returns_true(
     # Push monotonic past TIMEOUT_RECENTLY_BRUSHING so the long interval wins.
     mocked_time.monotonic.return_value = 10_000
     assert parser.poll_needed(None, 86401) is True
+
+
+# ---------------------------------------------------------------------------
+# Sector decoding for 6-sector brushes (IO Series 10)
+#
+# The advertisement bytes below are from a real full-session capture of an
+# IO Series 10 (6 sectors, number_of_sectors == 6) contributed by @smartmatic
+# (mtheli/toothbrush-card#3). Only the raw manufacturer-data bytes are used;
+# the device address is replaced with the placeholder used elsewhere here.
+#
+# The old hand-built SECTOR_MAP could not decode these:
+#   * byte 0x05 -> "unknown sector code 5"          (sector 5 is missing)
+#   * byte 0x07 -> "sector 4"                        (it is the last-quadrant
+#                                                     sentinel == sector 6 here)
+#   * byte 0x0c -> "unknown sector code 12"          (sector 4 with a display
+#                                                     flag set; not in the map)
+# ---------------------------------------------------------------------------
+ORALB_IO_SERIES_10_SECTOR_5 = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x062n\x03R\x01\x14\x00\x05\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+ORALB_IO_SERIES_10_SECTOR_6 = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x062n\x03R\x01(\x00\x07\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+ORALB_IO_SERIES_10_SECTOR_4_FLAGGED = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x062n\x03R\x01\x00\x00\x0c\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+# IO Series firmware that does not report a sector count (number_of_sectors == 0)
+# while actively brushing the last quadrant. Real capture, byte 0x07, N == 0.
+ORALB_IO_SERIES_NO_COUNT_RUNNING = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x0612\x03r\x02\x03\x00\x07\x00\x00"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+_SECTOR_KEY = DeviceKey(key="sector", device_id=None)
+_NUMBER_OF_SECTORS_KEY = DeviceKey(key="number_of_sectors", device_id=None)
+
+
+def _sector_value(service_info: BluetoothServiceInfo) -> str:
+    parser = OralBBluetoothDeviceData()
+    result = parser.update(service_info)
+    return result.entity_values[_SECTOR_KEY].native_value
+
+
+def test_io_series_10_sector_5():
+    """Sector 5 was previously reported as 'unknown sector code 5'."""
+    assert _sector_value(ORALB_IO_SERIES_10_SECTOR_5) == "sector 5"
+
+
+def test_io_series_10_sector_6():
+    """The last-quadrant sentinel (0x07) is sector 6 on a 6-sector brush."""
+    parser = OralBBluetoothDeviceData()
+    result = parser.update(ORALB_IO_SERIES_10_SECTOR_6)
+    assert result.entity_values[_SECTOR_KEY].native_value == "sector 6"
+    assert result.entity_values[_NUMBER_OF_SECTORS_KEY].native_value == 6
+
+
+def test_io_series_10_sector_4_with_display_flag():
+    """Upper display-flag bits must not change the decoded quadrant."""
+    assert _sector_value(ORALB_IO_SERIES_10_SECTOR_4_FLAGGED) == "sector 4"
+
+
+def test_io_series_last_quadrant_without_sector_count():
+    """Firmware that omits the sector count falls back to four sectors."""
+    assert _sector_value(ORALB_IO_SERIES_NO_COUNT_RUNNING) == "sector 4"


### PR DESCRIPTION
## Problem

The `sector` sensor is wrong on 6-sector brushes (e.g. **IO Series 10**). The current `SECTOR_MAP` was hand-built from 4-sector captures and cannot express the 6-sector case:

- byte `0x05` → `"unknown sector code 5"` — **sector 5 is missing**
- byte `0x07` → `"sector 4"` — but `0x07` is a *"last quadrant"* sentinel, so on a 6-sector brush it means **sector 6**, not 4
- byte `0x0c` → `"unknown sector code 12"` — sector 4 with the upper display-flag bit set; not in the map

A flat lookup table fundamentally can't resolve this, because the same byte `0x07` means *sector 4* on a 4-sector brush and *sector 6* on a 6-sector one — it needs the sector count (byte 10) as context.

## Fix

Replace `SECTOR_MAP` with `_decode_sector(sector, no_of_sectors)`:

```python
quadrant = sector & 0x07            # low 3 bits = quadrant index
if quadrant == 0:
    return "no sector"
if quadrant == 7:                   # "last quadrant" sentinel
    count = (no_of_sectors or 0) & 0x07
    return f"sector {count or 4}"   # firmware that omits the count -> 4
return f"sector {quadrant}"
```

The upper bits of byte 8 are a display flag (which feedback face the handle shows) and don't affect the quadrant, so they're masked off.

This is **backwards compatible**: the formula reproduces *every* existing `SECTOR_MAP` entry for 4-sector brushes byte-for-byte (`1,9→s1`; `2,10→s2`; `3,11,19,27→s3`; `4,7,15,31,39→s4`), so all existing tests pass unchanged. It additionally decodes sectors 5 and 6 and the display-flag variants the table was missing.

The `if state != "running"` override that forces `"no sector"` when idle is unchanged, so the post-session "success" frames behave exactly as before.

## Tests

Added focused tests using **real advertisement bytes from a full IO Series 10 session** (6 sectors), contributed by @smartmatic in [mtheli/toothbrush-card#3](https://github.com/mtheli/toothbrush-card/issues/3) — raw manufacturer data only, no device address:

- `test_io_series_10_sector_5` — `0x05` → `sector 5`
- `test_io_series_10_sector_6` — `0x07` (N=6) → `sector 6`
- `test_io_series_10_sector_4_with_display_flag` — `0x0c` → `sector 4`
- `test_io_series_last_quadrant_without_sector_count` — `0x07` (N=0) → `sector 4` (fallback)

All 47 tests pass; `wire-format.md` updated with a "Sector byte bit-encoding" section mirroring the existing pressure-byte docs.
