### PR TITLE
ci: validate PR title instead of individual commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,6 @@ jobs:
           python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
 
-  # Make sure commit messages follow the conventional commits convention:
-  # https://www.conventionalcommits.org
-  commitlint:
-    name: Lint Commit Messages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
-
   test:
     strategy:
       fail-fast: false
@@ -69,7 +58,6 @@ jobs:
     needs:
       - test
       - lint
-      - commitlint
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,51 @@
+name: Lint PR Title
+
+# GitHub uses the pull request title as the commit subject when "Squash and
+# merge" is used, and the repo is configured for squash-merge only with
+# squash_merge_commit_title = PR_TITLE. Individual commits on a PR branch
+# are discarded by the squash, so this workflow — which validates the PR
+# title against the Conventional Commits spec — is the sole enforcement
+# point for the format of the commit that lands on main.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Conventional Commits types accepted by @commitlint/config-conventional,
+          # matching the commitizen pre-commit hook used locally.
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          requireScope: false
+          # Subject (text after the type/scope) must start lowercase, matching
+          # @commitlint/config-conventional's subject-case rule.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Ready to contribute? Here's how to set yourself up for local development.
    $ git push origin name-of-your-bugfix-or-feature
    ```
 
-   Note: the commit message should follow [the conventional commits](https://www.conventionalcommits.org). We run [`commitlint` on CI](https://github.com/marketplace/actions/commit-linter) to validate it, and if you've installed pre-commit hooks at the previous step, the message will be checked at commit time.
+   Note: the PR title — which GitHub uses as the squash-merge commit subject — must follow [the conventional commits](https://www.conventionalcommits.org). CI runs [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) on the title to enforce it. If you've installed pre-commit hooks at the previous step, the `commitizen` hook will also flag individual commit messages locally.
 
 8. Submit a pull request through the GitHub website or using the GitHub CLI (if you have it installed):
 

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,8 +1,0 @@
-export default {
-  extends: ["@commitlint/config-conventional"],
-  rules: {
-    "header-max-length": [0, "always", Infinity],
-    "body-max-line-length": [0, "always", Infinity],
-    "footer-max-line-length": [0, "always", Infinity],
-  },
-};


### PR DESCRIPTION
The repo is squash merge only and the PR title becomes the commit on main, so linting every commit on a PR branch is pointless noise. This adds a pr-title workflow that checks the title against conventional commits, removes the commitlint job and its config, and updates CONTRIBUTING.md to match; same setup as dbus-fast and python-zeroconf.