### PR TITLE
fix: decode the pressure/status byte as a bit field

### DIFF
--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -130,6 +130,10 @@ STATES = {
     116: "transport",
 }
 
+# Known pressure/status byte values and their meaning. The parser decodes the
+# byte with _decode_pressure below; this table documents the observed value
+# space (Home Assistant imports it to build the sensor's enum options) and
+# doubles as the regression oracle in the tests.
 PRESSURE = {
     0: "normal",
     16: "normal",
@@ -157,6 +161,26 @@ PRESSURE = {
     240: "high",
     242: "high",
 }
+
+
+def _decode_pressure(pressure: int) -> str:
+    """Decode the pressure/status code (manufacturer data byte 4).
+
+    The byte is a bit field: bit 3 flags a power-button press, bit 2 a
+    (mode-)button press and bit 7 high pressure; the remaining bits are
+    display flags. Button presses take precedence over the pressure flag.
+    Reproduces every entry of the ``PRESSURE`` table byte-for-byte while
+    also covering values missing from it (e.g. 112 and 120 seen on the
+    iO Series 8).
+    """
+    if pressure & 0x08:
+        return "power button pressed"
+    if pressure & 0x04:
+        return "button pressed"
+    if pressure & 0x80:
+        return "high"
+    return "normal"
+
 
 ACTIVE_CONNECTION_PRESSURE = {0: "low", 1: "normal", 2: "high"}
 
@@ -276,7 +300,7 @@ class OralBBluetoothDeviceData(BluetoothData):
         self.set_title(name)
         tb_state = STATES.get(state, f"unknown state {state}")
         tb_mode = self.brush_modes.get(mode, f"unknown mode {mode}")
-        tb_pressure = PRESSURE.get(pressure, f"unknown pressure {pressure}")
+        tb_pressure = _decode_pressure(pressure)
         tb_sector = _decode_sector(sector, no_of_sectors)
 
         self.update_sensor(str(OralBSensor.TIME), None, brush_time, None, "Time")

--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -130,10 +130,12 @@ STATES = {
     116: "transport",
 }
 
-# Known pressure/status byte values and their meaning. The parser decodes the
-# byte with _decode_pressure below; this table documents the observed value
+# Known pressure/status byte values and their meaning. This table no longer
+# drives decoding -- _decode_pressure below is the authority -- so adding an
+# entry here does NOT change parser behaviour. It documents the observed value
 # space (Home Assistant imports it to build the sensor's enum options) and
-# doubles as the regression oracle in the tests.
+# doubles as the regression oracle in the tests; extend it when a new byte is
+# observed (see the debug log in _decode_pressure) to keep both in sync.
 PRESSURE = {
     0: "normal",
     16: "normal",
@@ -147,8 +149,10 @@ PRESSURE = {
     82: "normal",
     86: "button pressed",
     90: "power button pressed",
+    112: "normal",
     114: "normal",
     118: "button pressed",
+    120: "power button pressed",
     122: "power button pressed",
     144: "high",
     146: "high",
@@ -173,6 +177,12 @@ def _decode_pressure(pressure: int) -> str:
     also covering values missing from it (e.g. 112 and 120 seen on the
     iO Series 8).
     """
+    if pressure not in PRESSURE:
+        # Every byte still maps to one of the four known strings, but a value
+        # outside the documented set may carry a not-yet-understood flag in
+        # bits 0-1/4-6. Surface it so the observed space can keep growing
+        # without regressing the user-facing state.
+        _LOGGER.debug("Unmapped pressure/status byte: %s", pressure)
     if pressure & 0x08:
         return "power button pressed"
     if pressure & 0x04:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from unittest import mock
 
 import pytest
@@ -3488,3 +3489,13 @@ def test_pressure_120_decodes_as_power_button() -> None:
     parser = OralBBluetoothDeviceData()
     result = parser.update(ORALB_IO_SERIES_PRESSURE_120)
     assert result.entity_values[_PRESSURE_KEY].native_value == "power button pressed"
+
+
+def test_decode_pressure_unmapped_byte_still_decodes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A byte outside the documented table decodes and is logged at debug."""
+    # 116 (0x74) is not in PRESSURE but has the button bit set.
+    with caplog.at_level(logging.DEBUG, logger="oralb_ble.parser"):
+        assert _decode_pressure(116) == "button pressed"
+    assert "Unmapped pressure/status byte: 116" in caplog.text

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,7 +17,12 @@ from sensor_state_data import (
 )
 
 from oralb_ble.const import CHARACTERISTIC_PRESSURE
-from oralb_ble.parser import SMART_SERIES_MODES, OralBBluetoothDeviceData
+from oralb_ble.parser import (
+    PRESSURE,
+    SMART_SERIES_MODES,
+    OralBBluetoothDeviceData,
+    _decode_pressure,
+)
 
 from . import generate_ble_device
 
@@ -3435,3 +3440,51 @@ def test_io_series_10_sector_4_with_display_flag() -> None:
 def test_io_series_last_quadrant_without_sector_count() -> None:
     """Firmware that omits the sector count falls back to four sectors."""
     assert _sector_value(ORALB_IO_SERIES_NO_COUNT_RUNNING) == "sector 4"
+
+
+# iO Series 8 advertisement with pressure/status byte 112 (0x70) — previously
+# surfaced as "unknown pressure 112". Same frame layout as the other iO
+# fixtures; only byte 4 differs.
+ORALB_IO_SERIES_PRESSURE_112 = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x0612\x03p\x02\x03\x00\x02\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+# The same frame with byte 4 = 120 (0x78, power-button bit set) — previously
+# "unknown pressure 120".
+ORALB_IO_SERIES_PRESSURE_120 = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x0612\x03x\x02\x03\x00\x02\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+_PRESSURE_KEY = DeviceKey(key="pressure", device_id=None)
+
+
+def test_decode_pressure_reproduces_known_table() -> None:
+    """The bit-field decoder matches every previously mapped value."""
+    for value, expected in PRESSURE.items():
+        assert _decode_pressure(value) == expected
+
+
+def test_pressure_112_decodes_as_normal() -> None:
+    """112 has no button/pressure flag bits set and is plain 'normal'."""
+    parser = OralBBluetoothDeviceData()
+    result = parser.update(ORALB_IO_SERIES_PRESSURE_112)
+    assert result.entity_values[_PRESSURE_KEY].native_value == "normal"
+
+
+def test_pressure_120_decodes_as_power_button() -> None:
+    """120 carries the power-button flag (bit 3)."""
+    parser = OralBBluetoothDeviceData()
+    result = parser.update(ORALB_IO_SERIES_PRESSURE_120)
+    assert result.entity_values[_PRESSURE_KEY].native_value == "power button pressed"


### PR DESCRIPTION
## Problem

The advertisement's pressure/status byte is looked up in a hand-built 26-entry `PRESSURE` table. Values outside that table surface as `unknown pressure N` sensor states in Home Assistant — reported for **112** and **120** on an iO Series 8 (see the activity log screenshot in [mtheli/toothbrush-card#11](https://github.com/mtheli/toothbrush-card/issues/11#issuecomment-4973118225)).

## Analysis

Grouping the existing table by bits shows the byte is a bit field, not an enumeration:

- **bit 3** (0x08) → "power button pressed" (56, 58, 90, 122, 154, 186)
- **bit 2** (0x04) → "button pressed" (54, 86, 118, 150, 182)
- **bit 7** (0x80) → "high" (144, 146, 178, 192, 240, 242)
- none of those bits → "normal" (0, 16, 32, 48, 50, 80, 82, 114)

Button bits take precedence over the pressure bit in every existing entry (150, 154, 182, 186); the remaining bits vary freely (display/baseline flags). All 26 entries decode consistently — there are no contradictions.

I also verified this live on two handles (iO Series 6, Type 3753 and iO Series 7/8/9, Type 3758): holding the mode button flips exactly +0x04, the power button +0x08, and pressing too hard sets 0x80, on an otherwise stable baseline. The missing 112/120 are the same field on a baseline with bit 1 unset: 112 = plain "normal", 120 = "power button pressed".

## Change

- `_decode_pressure()` decodes the byte via the bit field; the parser uses it instead of the table lookup.
- The `PRESSURE` table is **kept**: it documents the observed value space, Home Assistant imports it to build the sensor's enum options, and the tests now use it as a regression oracle (`_decode_pressure` reproduces every entry byte-for-byte). The set of produced values is unchanged, so no changes are needed on the Home Assistant side.
- New tests: the full-table regression plus advertisement tests for 112 and 120.

52 tests pass; ruff/black clean.
