### PR TITLE
fix: name iO state 10 (post-brushing summary) and mode 11 (Smart Adapt)

### DIFF
--- a/src/oralb_ble/parser.py
+++ b/src/oralb_ble/parser.py
@@ -98,6 +98,7 @@ IO_SERIES_MODES = {
     6: "tongue cleaning",
     8: "settings",
     9: "off",
+    11: "smart adapt",
 }
 
 
@@ -124,6 +125,7 @@ STATES = {
     6: "flight menu",
     8: "selection menu",
     9: "off",
+    10: "post brushing statistics",
     113: "final test",
     114: "pcb test",
     115: "sleeping",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3499,3 +3499,45 @@ def test_decode_pressure_unmapped_byte_still_decodes(
     with caplog.at_level(logging.DEBUG, logger="oralb_ble.parser"):
         assert _decode_pressure(116) == "button pressed"
     assert "Unmapped pressure/status byte: 116" in caplog.text
+
+
+# iO advertisement with device-state byte 10 -- the post-brushing summary the
+# handle shows after a session (home-assistant/core#169661, #174882).
+ORALB_IO_SERIES_POST_BRUSHING = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x0612\x0ar\x00\x00\x03\x01\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+# iO9 advertisement while brushing in the Smart Adapt mode (mode byte == 11),
+# previously surfaced as unknown_mode_11 (home-assistant/core#174882).
+ORALB_IO_SERIES_SMART_ADAPT = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    manufacturer_data={220: b"\x0612\x03r\x00\x05\x0b\x01\x00\x06"},
+    service_uuids=["0000fe0d-0000-1000-8000-00805f9b34fb"],
+    service_data={},
+    source="local",
+)
+
+_STATE_KEY = DeviceKey(key="toothbrush_state", device_id=None)
+_MODE_KEY = DeviceKey(key="mode", device_id=None)
+
+
+def test_state_10_is_post_brushing_statistics() -> None:
+    """State 10 is the post-brushing summary screen, not an unknown state."""
+    parser = OralBBluetoothDeviceData()
+    result = parser.update(ORALB_IO_SERIES_POST_BRUSHING)
+    assert result.entity_values[_STATE_KEY].native_value == "post brushing statistics"
+
+
+def test_mode_11_is_smart_adapt() -> None:
+    """Mode 11 on the iO series is the Smart Adapt mode."""
+    parser = OralBBluetoothDeviceData()
+    result = parser.update(ORALB_IO_SERIES_SMART_ADAPT)
+    assert result.entity_values[_MODE_KEY].native_value == "smart adapt"


### PR DESCRIPTION
## Problem

Two values reported by newer iO handles are missing from the lookup tables, so Home Assistant's Oral-B integration shows them as `unknown_state_10` and `unknown_mode_11`:

- **State 10** appears after a brushing session, while the handle displays its post-brushing summary screen (optimal-pressure time, brush-head life, …). The state persists until the brush is woken again. Reported for the iO 6 in [home-assistant/core#169661](https://github.com/home-assistant/core/issues/169661) and the iO 9 in [home-assistant/core#174882](https://github.com/home-assistant/core/issues/174882); a user in #169661 identified it as the summary screen.
- **Mode 11** is the **Smart Adapt** brushing mode on the iO 9, reported in [home-assistant/core#174882](https://github.com/home-assistant/core/issues/174882).

## Change

- `STATES[10] = "post brushing statistics"`
- `IO_SERIES_MODES[11] = "smart adapt"`

Both are additive — they only fill previously unmapped values, so existing devices are unaffected. A test is added for each.

## Note for the Home Assistant bump

The `oralb` integration builds its enum options from `STATES` and `IO_SERIES_MODES`, so `strings.json` needs matching `post_brushing_statistics` and `smart_adapt` translation keys. Happy to open that PR once this is released.
